### PR TITLE
Fix dependency: use stable_audio_tools==0.0.16 instead of non-existent 1.0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jupyter
 torch
 torchvision
 torchaudio
-stable_audio_tools==1.0.16
+stable_audio_tools==0.0.16
 einops
 datasets[audio]
 yt-dlp


### PR DESCRIPTION
The previous requirement stable_audio_tools==1.0.16 refers to a non-existent version on `PyPI`, which causes installation to fail.
- This PR changes the version to `0.0.16`, which is the available version (late versions are not compatible) and also resolves the associated issue.